### PR TITLE
fix to run jaxrl on Windows

### DIFF
--- a/jaxrl/networks/policies.py
+++ b/jaxrl/networks/policies.py
@@ -128,7 +128,7 @@ class NormalTanhMixturePolicy(nn.Module):
 
 
 @jax.partial(jax.jit, static_argnums=(1, 5))
-def sample_actions(
+def _sample_actions(
         rng: PRNGKey,
         actor_def: nn.Module,
         actor_params: Params,
@@ -143,3 +143,13 @@ def sample_actions(
                                temperature)
         rng, key = jax.random.split(rng)
         return rng, dist.sample(seed=key)
+
+
+def sample_actions(
+        rng: PRNGKey,
+        actor_def: nn.Module,
+        actor_params: Params,
+        observations: np.ndarray,
+        temperature: float = 1.0,
+        distribution: str = 'log_prob') -> Tuple[PRNGKey, jnp.ndarray]:
+    return _sample_actions(rng,actor_def,actor_params,observations,temperature,distribution)


### PR DESCRIPTION
Very nice repo, thanks!
I got some error, but with this fix, I could train on Windows, including creation of videos etc.
```
TypeError: Jitted function has static_argnums=(3,) but was called with only 0 positional arguments.
```
The fix is described here: https://github.com/google/jax/issues/1159